### PR TITLE
Use exception's message as log message so that Google Cloud wouldn't …

### DIFF
--- a/server/src/klite/Logger.kt
+++ b/server/src/klite/Logger.kt
@@ -7,4 +7,4 @@ fun Any.logger(name: String = javaClass.name): System.Logger = System.getLogger(
 inline fun System.Logger.info(msg: String) = log(INFO, msg)
 inline fun System.Logger.warn(msg: String) = log(WARNING, msg)
 inline fun System.Logger.error(msg: String, e: Throwable? = null) = log(ERROR, msg, e)
-inline fun System.Logger.error(e: Throwable) = log(ERROR, "", e)
+inline fun System.Logger.error(e: Throwable) = log(ERROR, e.message ?: e::class.qualifiedName ?: "", e)

--- a/server/src/klite/Logger.kt
+++ b/server/src/klite/Logger.kt
@@ -7,4 +7,4 @@ fun Any.logger(name: String = javaClass.name): System.Logger = System.getLogger(
 inline fun System.Logger.info(msg: String) = log(INFO, msg)
 inline fun System.Logger.warn(msg: String) = log(WARNING, msg)
 inline fun System.Logger.error(msg: String, e: Throwable? = null) = log(ERROR, msg, e)
-inline fun System.Logger.error(e: Throwable) = log(ERROR, e.message ?: e::class.qualifiedName ?: "", e)
+inline fun System.Logger.error(e: Throwable) = log(ERROR, e.message ?: e.javaClass.name, e)

--- a/slf4j/README.md
+++ b/slf4j/README.md
@@ -1,19 +1,24 @@
 # klite-slf4j
 
 As many Java libraries already depend on slf4j-api instead of the built-in System.Logger,
-adding this dependency will redirect System.Logger to slf4j and use a simple implementation for
-actual lightweight logging to System.out.
+adding this dependency will redirect System.Logger to slf4j and provide a simple implementation for
+logging to System.out.
 
 The following Config properties are supported:
 * `LOGGER=INFO` - to set the default logger level
 * `LOGGER.logger.name=DEBUG` - to set some logger to another level (with usual level inheritance from parent logger)
 
-If you want to redefine the logging format, define extend [KliteLogger](src/KliteLogger.kt) and specify it's full class name as `LOGGER_CLASS`.
+If you want to redefine the logging format, extend [KliteLogger](src/KliteLogger.kt) and specify it's full class name as `LOGGER_CLASS`.
+
+There are two non-default implemtations available:
+* `klite.slf4j.StackTraceOptimizingLogger` - this one will omit some lower stack trace frames that are not very useful
+* `klite.slf4j.StackTraceOptimizingJsonLogger` - this one will output exception and stack trace as a single-line json, friendly for log indexing services
 
 When deploying as a 12-factor app, this is all you need - logging to standard out.
 
 ## Other slf4j backends
 
 This module uses the slf4j 2.0 ServiceLoader mechanism to provide a simple logger to slf4j.
+This implementation is much lighter than `slf4j-simple.jar` and is easier to extend/configure.
 
-If you want to switch to another (bigger) backend (e.g. logback), then ensure that it supports slfj4 2.0 and that it is before this module on classpath.
+If you want to use another (much bigger) backend (e.g. logback), then ensure that it supports slfj4 2.0 and that it is before this module on classpath.


### PR DESCRIPTION
Use exception's message as log message so that Google Cloud wouldn't  show empty log rows