### PR TITLE
Fixed /todos duplication in the TUTORIAL.md

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -134,7 +134,7 @@ Then, you can register this class in the /api context:
 ```kotlin
   context("/api") {
     useOnly<JsonBody>()
-    annotated<TodoRoutes>("/todos")
+    annotated<TodoRoutes>()
   }
 ```
 


### PR DESCRIPTION
To keep the path as http://localhost:8080/api/todos, we should remove the "/todos" from the main fun as, at this moment, it has already moved to the class TodoRoutes.