### PR TITLE
Keep sample Dockerfile up-to-date

### DIFF
--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine as build
+FROM amazoncorretto:17-alpine3.20 as build
 
 WORKDIR /app
 RUN apk add binutils # for objcopy, needed by jlink

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 
 COPY --from=build /app/jre /app/jre
 COPY build/libs /app
+COPY public /app/public
 
 # Run under non-privileged user with minimal write permissions
 USER user


### PR DESCRIPTION
Image `openjdk:17-alpine` is deprecated, see https://hub.docker.com/_/openjdk, replacing it with `amazoncorretto:17-alpine3.20`, has less vulnerabilities and has arm64 build, I was not able to run `openjdk:17-alpine` on my M1 Mac without adding `platform: linux/x86_64` directive.

Also adding `public/` folder so server can serve static files.