### PR TITLE
Use Reflection instead of a Stacktrace for HttpClient Logger name

### DIFF
--- a/core/src/http/TypedHttpClient.kt
+++ b/core/src/http/TypedHttpClient.kt
@@ -2,7 +2,6 @@ package klite.http
 
 import klite.error
 import klite.info
-import klite.logger
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import java.io.IOException
@@ -32,9 +31,7 @@ open class TypedHttpClient(
   val contentType: String
 ) {
   protected var trimToLog: String.() -> String = { if (length <= maxLoggedLen) this else substring(0, maxLoggedLen) + "…" }
-  var logger = logger(Exception().stackTrace.first { it.className != TypedHttpClient::class.java.name && it.className !== javaClass.name }.className).apply {
-    if (urlPrefix.isNotEmpty()) info("Using $urlPrefix")
-  }
+  var logger = System.getLogger(this::class.java.name).apply { if (urlPrefix.isNotEmpty()) info("Using $urlPrefix") }
 
   private fun buildReq(urlSuffix: String) = HttpRequest.newBuilder().uri(URI("$urlPrefix$urlSuffix"))
     .setHeader("Content-Type", "application/json; charset=UTF-8").setHeader("Accept", "application/json")

--- a/core/test/TypedHttpClientTest.kt
+++ b/core/test/TypedHttpClientTest.kt
@@ -1,0 +1,30 @@
+package klite
+
+
+import ch.tutteli.atrium.api.fluent.en_GB.toEqual
+import ch.tutteli.atrium.api.verbs.expect
+import klite.http.TypedHttpClient
+import org.junit.jupiter.api.Test
+import java.net.http.HttpClient
+
+class TypedHttpClientLoggerNameTest {
+  @Test fun loggerNameShouldReferToClassName() {
+    expect(
+      TypedHttpClient(
+        urlPrefix = "",
+        http = HttpClient.newHttpClient(),
+        contentType = ""
+      ).logger.name
+    ).toEqual("klite.http.TypedHttpClient")
+  }
+
+  @Test fun loggerNameShouldReferToDerivedClassName() {
+    expect(DerivedTypedHttpClient().logger.name).toEqual("klite.DerivedTypedHttpClient")
+  }
+}
+
+private class DerivedTypedHttpClient: TypedHttpClient(
+  urlPrefix = "",
+  http = HttpClient.newHttpClient(),
+  contentType = "",
+)

--- a/jackson/test/JsonHttpClientTest.kt
+++ b/jackson/test/JsonHttpClientTest.kt
@@ -21,7 +21,7 @@ class JsonHttpClientTest {
     retryCount = 2, retryAfter = ZERO, http = httpClient, json = kliteJsonMapper())
 
   @Test fun `logger name from stack trace`() {
-    expect(http.logger.name).toEqual(javaClass.name)
+    expect(http.logger.name).toEqual(http.javaClass.name)
   }
 
   @Test fun get() {


### PR DESCRIPTION
Hi guys, first of all thanks for sharing Klite!

I stumbled upon a minor potential for improvement in the way the name of a logger is determined in classes derived from TypedHttpClient.
The Kotlin Reflection API can provide you with the name of the instantiated class. You might want to consider the Java StackWalk API in case the change I propose is not providing the name you had in mind for the logger.
Both approaches would avoid constructing a Stacktrace which is typically considered a costly operation on the JVM.