### PR TITLE
expose bound address

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -38,7 +38,7 @@ fun main() {
 ```
 
 This will start a server on the default port 8080.
-You can change the listening IP and port by passing it as an argument to the `Server` constructor.
+You can change the listening IP and port by passing it as an argument to the `Server` constructor. Passing `InetSocketAddress(0)` will bind to any available port.
 
 ## Config
 

--- a/sample/test/ServerIntegrationTest.kt
+++ b/sample/test/ServerIntegrationTest.kt
@@ -14,10 +14,10 @@ import java.net.http.HttpRequest.BodyPublishers.noBody
 
 class ServerIntegrationTest {
   @Test fun requests() {
-    val port = (Math.random() * 60000 + 1000).toInt()
-    val server = sampleServer(port).apply { start(gracefulStopDelaySec = -1) }
 
-    val http = JsonHttpClient("http://localhost:$port", registry = server.registry)
+    val server = sampleServer(0).apply { start(gracefulStopDelaySec = -1) }
+
+    val http = JsonHttpClient("http://localhost:${server.boundAddress.port}", registry = server.registry)
     runBlocking {
       expect(http.get<String>("/hello")).toEqual("\"Hello World\"")
       expect(http.get<String>("/hello/param/123456?query=123")).toEqual("\"Path: 123456, Query: {query=123}\"")

--- a/server/src/klite/Server.kt
+++ b/server/src/klite/Server.kt
@@ -40,9 +40,12 @@ class Server(
   private val requestScope = CoroutineScope(SupervisorJob() + workerPool.asCoroutineDispatcher())
   private val log = logger()
 
+  val boundAddress: InetSocketAddress
+    get() = http.address ?: error("The server is not yet started, hence no bound address is available.")
+
   fun start(gracefulStopDelaySec: Int = 3) {
     http.bind(listen, 0)
-    log.info("Listening on $listen")
+    log.info("Listening on $boundAddress")
     http.start()
     if (gracefulStopDelaySec >= 0) getRuntime().addShutdownHook(thread(start = false) { stop(gracefulStopDelaySec) })
   }

--- a/server/test/klite/ServerTest.kt
+++ b/server/test/klite/ServerTest.kt
@@ -1,0 +1,40 @@
+package klite
+
+import ch.tutteli.atrium.api.fluent.en_GB.*
+import ch.tutteli.atrium.api.verbs.expect
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import kotlin.random.Random
+
+class ServerTest {
+  @Test fun `bind server to any available port`() {
+    val server = Server(listen = InetSocketAddress( 0))
+    try {
+      server.start(gracefulStopDelaySec = -1)
+      expect(server.boundAddress.port).toBeGreaterThan(0)
+    } finally {
+      server.stop()
+    }
+  }
+
+  @Test fun `bind server to custom port`() {
+    val port = Random.nextInt(1024, 65535) + 1
+    val server = Server(listen = InetSocketAddress(port))
+    try {
+      server.start(gracefulStopDelaySec = -1)
+      expect(server.boundAddress.port).toEqual(port)
+    } finally {
+      server.stop()
+    }
+  }
+
+  @Test fun `fail to expose bound address if server is not started`() {
+    val port = 8080
+    val server = Server(listen = InetSocketAddress(port))
+    expect { server.boundAddress.port }
+      .toThrow<IllegalStateException> {
+        message { toContain("is not yet started") }
+      }
+  }
+}
+

--- a/server/test/klite/ServerTest.kt
+++ b/server/test/klite/ServerTest.kt
@@ -13,7 +13,7 @@ class ServerTest {
       server.start(gracefulStopDelaySec = -1)
       expect(server.boundAddress.port).toBeGreaterThan(0)
     } finally {
-      server.stop()
+      server.stop(0)
     }
   }
 
@@ -24,7 +24,7 @@ class ServerTest {
       server.start(gracefulStopDelaySec = -1)
       expect(server.boundAddress.port).toEqual(port)
     } finally {
-      server.stop()
+      server.stop(0)
     }
   }
 


### PR DESCRIPTION
Thank you for sharing klite with the world.

With this PR I am proposing to expose the address the server is actually bound, allowing users (most likely in integration tests) to start the server on any available port. Looking forward to your feedback.